### PR TITLE
Add missing actions for programmatic access

### DIFF
--- a/doc_source/account-factory.md
+++ b/doc_source/account-factory.md
@@ -32,6 +32,7 @@ With Account Factory, central cloud administrators and AWS Single Sign\-On end u
                 "sso:ProvisionApplicationProfileForAWSAccountInstance",
                 "sso:ProvisionSAMLProvider",
                 "sso:ListProfileAssociations",
+                "sso:DescribeRegisteredRegions",
                 "sso-directory:ListMembersInGroup",
                 "sso-directory:AddMemberToGroup",
                 "sso-directory:SearchGroups",
@@ -44,7 +45,8 @@ With Account Factory, central cloud administrators and AWS Single Sign\-On end u
                 "controltower:CreateManagedAccount",
                 "controltower:DescribeManagedAccount",
                 "controltower:DeregisterManagedAccount",
-                "s3:GetObject"
+                "s3:GetObject",
+                "organizations:DescribeOrganization"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
*Description of changes:*
sso:DescribeRegisteredRegions and organizations:DescribeOrganization are both required to provision control tower accounts programmatic. Without these provisioning fails with permissions problems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
